### PR TITLE
Add compatibility to pylint 2.12 and more

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.egg-info/
 dist/
+__pycache__

--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ cnes-pylint-extension checks the following metrics :
 - Version 2.0 - compatible pylint 1.6
 - Version 3.0 - compatible pylint 1.7.4 and 1.9.1
 - Version 4.0 - compatible pylint 2.1.1
-- Version 5.0 - compatible pylint 2.5.0
+- Version 5.0 - compatible pylint >=2.5.0,<2.12.0
+- Version 6.0 - compatible pylint >=2.12,<3.0.0
+    - **warning**: At 6.0.0 release, latest pylint was 2.13.5. If you encounter issue with pylint>2.13.5 and <3.0.0 please open an issue.
 
 # To use these checkers:
 
@@ -37,7 +39,7 @@ cnes-pylint-extension checks the following metrics :
 
 ### Install Pylint
 
-`pip install pylint==2.5.0`
+`pip install pylint==2.13.5`
 
 ### Install CNES Pylint extension checkers
 

--- a/setup.py
+++ b/setup.py
@@ -5,9 +5,9 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="cnes-pylint-extension",
-    version="5.0.0",
+    version="6.0.0",
     author="CNES CatLab",
-    description="A PyLint plugin to add coding CNES specific checks",
+    description="A PyLint plugin to add CNES specific checks",
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/cnescatlab/cnes-pylint-extension",
@@ -22,7 +22,7 @@ setuptools.setup(
     python_requires='>=3.6',
     install_requires=[
         "pylint-plugin-utils==0.7",
-        "pylint==2.5.0"
+        "pylint>=2.12.0,<3.0.0"
     ],
     project_urls={
         'Bug Reports': 'https://github.com/cnescatlab/cnes-pylint-extension/issues'


### PR DESCRIPTION
This merge request fix an issue that generates a crash with Pylint>=2.12

# Breaking change:
- As the issue was directly caused by an hardcoded value in pylint (see https://github.com/PyCQA/pylint/commit/16c09cb48a3c66f453faccdf380aea6969d61202#diff-0228810a23bfd655bcef18bf30e29afdec87527bbafb644917dd5e6721c932b5L117 ) it may not work with pylint<2.12 anymore

# Notes
- Tested with pylint 2.12, 2.13.5
- No warranty of work with pylint 3.0.0 or more (not releasec yet)